### PR TITLE
Issue1/vertical

### DIFF
--- a/src/color-grid.js
+++ b/src/color-grid.js
@@ -1,40 +1,40 @@
 (function () {
   "use strict";
 
-  var currentBodyColor = new Rgb(),
+  var currentBodyColor,
     body,
     bodyX;
 
-    function Rgb(r, g, b) {
-        r = parseInt(r, 10);
-        g = parseInt(g, 10);
-        b = parseInt(b, 10);
+  function Hsl(h, s, l) {
+    h = parseInt(h, 10);
+    s = parseInt(s, 10);
+    l = parseInt(l, 10);
 
-        if (r !== r || (r > 255 || r < 0)) {
-          r = 255;
-        }
+    if (h !== h || h > 360 || h < 0) {
+      h = 0;
+    }
 
-        if (g !== g || (g > 255 || g < 0)) {
-          g = 255;
-        }
+    if (s !== s || s > 100 || s < 0) {
+      s = 100;
+    }
 
-        if (b !== b || (b > 255 || b < 0)) {
-          b = 255;
-        }
+    if (l !== l || l > 100 || l < 0) {
+      l = 50;
+    }
 
-        this.r = r;
-        this.g = g;
-        this.b = b;
-      }
+    this.h = h;
+    this.s = s;
+    this.l = l;
+  }
 
-  Rgb.prototype.toString = function () {
-    return "rgb(" + this.r + "," + this.g + "," + this.b + ")";
+  Hsl.prototype.toString = function () {
+    return "hsl(" + this.h + ", " + this.s + "%, " + this.l + "%)";
   };
 
-  Rgb.prototype.isEqual = function (other) {
-    if (this.r === other.r &&
-        this.b === other.b &&
-        this.g === other.g) {
+  Hsl.prototype.isEqual = function (other) {
+    if (this.h === other.h &&
+        this.s === other.s &&
+        this.l === other.l) {
       return true;
     }
     return false;
@@ -54,67 +54,8 @@
     return 360 * mouseX / width;
   }
 
-  function getIntensityfromScaledX(scaledX, color) {
-
-    var start,
-      finalValue;
-
-    color = typeof color !== 'undefined' ? color : 'r';
-
-    if (typeof(scaledX) !== "number" ||
-      scaledX !== scaledX ||
-      scaledX < 0 ||
-      scaledX > 360) {
-        scaledX = 0;
-    }
-
-    switch (color) {
-    case "r":
-      start = (scaledX + 240) % 360;
-      break;
-    case "g":
-      start = (scaledX + 120) % 360;
-      break;
-    case "b":
-      start = scaledX % 360;
-      break;
-    }
-
-    function piecewiseUp(x) {
-      return 4.25 * x - 510;
-    }
-
-    function piecewiseDown(x) {
-      return 1530 - 4.25 * x;
-    }
-
-    if (start >= 0 && start < 120) {
-      finalValue = 0;
-    } else if (start >= 120 && start < 180) {
-      finalValue = piecewiseUp(start);
-    } else if (start >= 180 && start < 300) {
-      finalValue = 255;
-    } else if (start >= 300 && start < 360) {
-      finalValue = piecewiseDown(start);
-    }
-
-    return finalValue;
-  }
-
-  function getRgbFromScaledX(scaledX) {
-    var r, g, b;
-
-    r = getIntensityfromScaledX(scaledX, "r");
-    g = getIntensityfromScaledX(scaledX, "g");
-    b = getIntensityfromScaledX(scaledX, "b");
-
-    return new Rgb(r, g, b);
-  }
-
   function getBodyWidth() {
-    return window.innerWidth
-      || document.documentElement.clientWidth
-      || document.body.clientWidth;
+    return window.innerWidth;
   }
 
   function resize() {
@@ -126,14 +67,16 @@
 
       var mouseX = e.screenX,
         scaledX = getScaledX(mouseX, bodyX),
-        color = getRgbFromScaledX(scaledX);
+        color = new Hsl(scaledX, 100, 50);
 
       if (!color.isEqual(currentBodyColor)) {
-        body.style.backgroundColor = color.toString();
+        body.style.background = color.toString();
         currentBodyColor = color;
       }
     });
   }
+
+  currentBodyColor = new Hsl();
 
   document.addEventListener('DOMContentLoaded', function () {
     body = document.getElementsByTagName('body')[0];
@@ -145,12 +88,8 @@
 
   /* test-code */
   var exports = module.exports = {
-    Rgb: Rgb,
-    Rgb_toString: Rgb.toString,
-    Rgb_isEqual: Rgb.isEqual,
-    getScaledX: getScaledX,
-    getIntensityfromScaledX: getIntensityfromScaledX,
-    getRgbFromScaledX: getRgbFromScaledX
+    Hsl: Hsl,
+    getScaledX: getScaledX
   };
   /* end-test-code */
 

--- a/src/color-grid.js
+++ b/src/color-grid.js
@@ -3,7 +3,8 @@
 
   var currentBodyColor,
     body,
-    bodyX;
+    bodyX,
+    bodyY;
 
   function Hsl(h, s, l) {
     h = parseInt(h, 10);
@@ -51,45 +52,57 @@
     if (mouseX > width) {
       return 360;
     }
-    return 360 * mouseX / width;
+    return parseInt(360 * mouseX / width, 10);
   }
 
-  function getBodyWidth() {
-    return window.innerWidth;
+  // return a scaled y value on a scale from 15 to 85, inclusive
+  function getScaledY(mouseX, width) {
+    if (typeof(mouseX) !== "number" ||
+      typeof(width) !== "number" ||
+      mouseX < 0 ||
+      mouseX !== mouseX ||
+      width !== width) {
+      return 15;
+    }
+    if (mouseX > width) {
+      return 85;
+    }
+    // the total range is 70: 85 - 15
+    return parseInt(70 * mouseX / width + 15, 10);
   }
 
-  function resize() {
-    bodyX = getBodyWidth();
-  }
-
-  function addMouseOverFunc() {
-    document.addEventListener("mousemove", function (e) {
-
-      var mouseX = e.screenX,
-        scaledX = getScaledX(mouseX, bodyX),
-        color = new Hsl(scaledX, 100, 50);
-
-      if (!color.isEqual(currentBodyColor)) {
-        body.style.background = color.toString();
-        currentBodyColor = color;
-      }
-    });
+  function setWidthAndHeight() {
+    bodyX = window.innerWidth;
+    bodyY = window.innerHeight;
   }
 
   currentBodyColor = new Hsl();
 
   document.addEventListener('DOMContentLoaded', function () {
     body = document.getElementsByTagName('body')[0];
-    bodyX = getBodyWidth();
-    addMouseOverFunc();
+    setWidthAndHeight();
+
+    document.addEventListener("mousemove", function (e) {
+      var mouseX = e.clientX,
+        mouseY = e.clientY,
+        scaledX = getScaledX(mouseX, bodyX),
+        scaledY = getScaledY(mouseY, bodyY),
+        color = new Hsl(scaledX, 100, scaledY);
+
+      if (!color.isEqual(currentBodyColor)) {
+        body.style.background = color.toString();
+        currentBodyColor = color;
+      }
+    });
   });
 
-  window.onresize = resize;
+  window.onresize = setWidthAndHeight;
 
   /* test-code */
   var exports = module.exports = {
     Hsl: Hsl,
-    getScaledX: getScaledX
+    getScaledX: getScaledX,
+    getScaledY: getScaledY
   };
   /* end-test-code */
 

--- a/test/color-grid-test.js
+++ b/test/color-grid-test.js
@@ -1,55 +1,65 @@
 var jsdom = require("jsdom"),
 expect = require("chai").expect;
 
+/*jshint -W020 */
 document = jsdom.jsdom("<!doctype html><html><body></body></html>");
 window   = document.defaultView;
+/*jshint +W020 */
 
 var color_grid = require("../src/color-grid.js");
 
-describe("Rgb", function() {
+describe("Hsl", function() {
   describe("constructor", function() {
-    it("should return an Rgb object with the submitted RGB values, rounded down to 0 decimal places", function () {
-        var rgb1 = new color_grid.Rgb(1,2.14,3.99);
-        expect(rgb1 instanceof color_grid.Rgb);
-        expect(rgb1.r).to.equal(1);
-        expect(rgb1.g).to.equal(2);
-        expect(rgb1.b).to.equal(3);
+    it("should return an Hsl object with the submitted h, s, l values, rounded down to 0 decimal places", function () {
+        var hsl = new color_grid.Hsl(160.3,87.3,3.99);
+        expect(hsl instanceof color_grid.Hsl);
+        expect(hsl.h).to.equal(160);
+        expect(hsl.s).to.equal(87);
+        expect(hsl.l).to.equal(3);
     });
-    it("should return an object with r, g, and b equal to 255, when called with null or weird values", function () {
-      var rgb1 = new color_grid.Rgb(),
-      rgb2 = new color_grid.Rgb("g", -10, 1700);
-      expect(rgb1.r).to.equal(255);
-      expect(rgb1.g).to.equal(255);
-      expect(rgb1.b).to.equal(255);
-      expect(rgb2.r).to.equal(255);
-      expect(rgb2.g).to.equal(255);
-      expect(rgb2.b).to.equal(255);
+    it("should return an object with h, s, l equal to 0, 100, 50 respectively when called with non number or weird values", function() {
+      var hsl1 = new color_grid.Hsl(),
+      hsl2 = new color_grid.Hsl("g", -10, 1700);
+      hsl3 = new color_grid.Hsl(1700, "g", -10);
+      hsl4 = new color_grid.Hsl(-10, 1700, "g");
+      expect(hsl1.h).to.equal(0);
+      expect(hsl1.s).to.equal(100);
+      expect(hsl1.l).to.equal(50);
+      expect(hsl2.h).to.equal(0);
+      expect(hsl2.s).to.equal(100);
+      expect(hsl2.l).to.equal(50);
+      expect(hsl3.h).to.equal(0);
+      expect(hsl3.s).to.equal(100);
+      expect(hsl3.l).to.equal(50);
+      expect(hsl4.h).to.equal(0);
+      expect(hsl4.s).to.equal(100);
+      expect(hsl4.l).to.equal(50);
     });
     it("should return an object with the correct values when the inputs are strings containing numbers", function() {
-      var rgb5 = new color_grid.Rgb("10", "55", "260");
-      expect(rgb5.r).to.equal(10);
-      expect(rgb5.g).to.equal(55);
-      expect(rgb5.b).to.equal(255);
+      var hsl = new color_grid.Hsl("10", "55", "99");
+      expect(hsl.h).to.equal(10);
+      expect(hsl.s).to.equal(55);
+      expect(hsl.l).to.equal(99);
     });
   });
   describe("toString", function() {
-    it("should return a valid CSS rgb string", function() {
-      var rgb = new color_grid.Rgb(1,2,3);
-      var rgb_string = rgb.toString();
-      expect(rgb_string).to.equal("rgb(1,2,3)");
+    it("should return a valid CSS hsl string", function() {
+      var hsl = new color_grid.Hsl(0,100,50);
+      var hsl_string = hsl.toString();
+      expect(hsl_string).to.equal("hsl(0, 100%, 50%)");
     });
   });
   describe("isEqual", function() {
-    it("should return true when two different Rgb objects have the same r, g, b values", function() {
-      var rgb1 = new color_grid.Rgb(1,2,3),
-        rgb2 = new color_grid.Rgb(1,2,3);
-      var areEqual = rgb1.isEqual(rgb2);
+    it("should return true when two different Hsl objects have the same h, s, l values", function() {
+      var hsl1 = new color_grid.Hsl(1,2,3),
+        hsl2 = new color_grid.Hsl(1,2,3);
+      var areEqual = hsl1.isEqual(hsl2);
       expect(areEqual).to.equal(true);
     });
-    it("should return false when two different Rgb objects have different r, g, b values", function() {
-      var rgb1 = new color_grid.Rgb(1,2,3),
-        rgb2 = new color_grid.Rgb(1,0,3);
-      var areEqual = rgb1.isEqual(rgb2);
+    it("should return false when two different Hsl objects have different h, s, l values", function() {
+      var hsl1 = new color_grid.Hsl(1,2,3),
+      hsl2 = new color_grid.Hsl(1,0,3);
+      var areEqual = hsl1.isEqual(hsl2);
       expect(areEqual).to.equal(false);
     });
   });
@@ -87,181 +97,5 @@ describe("getScaledX", function() {
     expect(color_grid.getScaledX(10, true)).to.equal(0);
     expect(color_grid.getScaledX(10, false)).to.equal(0);
     expect(color_grid.getScaledX(10, "string")).to.equal(0);
-  });
-});
-describe("getIntensityfromScaledX", function() {
-  describe("for the input color r", function() {
-    it("should return the correct values for numbers between 0 and 360, based on the color wheel", function() {
-      expect(color_grid.getIntensityfromScaledX(0, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(30, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(60, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(90, "r")).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(120, "r")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(150, "r")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(180, "r")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(210, "r")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(240, "r")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(270, "r")).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(300, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(330, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(360, "r")).to.equal(255);
-    });
-  });
-  describe("for the input color g", function() {
-    it("should return the correct values for numbers between 0 and 360, based on the color wheel", function() {
-      expect(color_grid.getIntensityfromScaledX(0, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(30, "g")).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(60, "g")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(90, "g")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(120, "g")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(150, "g")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(180, "g")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(210, "g")).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(240, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(270, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(300, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(330, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(360, "g")).to.equal(0);
-    });
-  });
-  describe("for the input color b", function() {
-    it("should return the correct values for numbers between 0 and 360, based on the color wheel", function() {
-      expect(color_grid.getIntensityfromScaledX(0, "b")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(30, "b")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(60, "b")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(90, "b")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(120, "b")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(150, "b")).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(180, "b")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(210, "b")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(240, "b")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(270, "b")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(300, "b")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(330, "b")).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(360, "b")).to.equal(0);
-    });
-  });
-  describe("when no color is given", function() {
-    it("should return the values for the color r", function() {
-      expect(color_grid.getIntensityfromScaledX(0)).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(30)).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(60)).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(90)).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(120)).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(150)).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(180)).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(210)).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(240)).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(270)).to.equal(127.5);
-      expect(color_grid.getIntensityfromScaledX(300)).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(330)).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(360)).to.equal(255);
-    });
-  });
-  describe("for color values below 0", function() {
-    it("should return the value as if 0 were the input", function() {
-      expect(color_grid.getIntensityfromScaledX(-10, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(-10, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(-10, "b")).to.equal(0);
-    });
-  });
-  describe("for values greater than 360", function() {
-    it("should return the value as if 0 were the input", function() {
-      expect(color_grid.getIntensityfromScaledX(1000, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(1000, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(1000, "b")).to.equal(0);
-    });
-  });
-  describe("for non number color values", function() {
-    it("should return the value as if 0 were the input", function() {
-      expect(color_grid.getIntensityfromScaledX("string", "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX("string", "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX("string", "b")).to.equal(0);
-
-      expect(color_grid.getIntensityfromScaledX(undefined, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(undefined, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(undefined, "b")).to.equal(0);
-
-      expect(color_grid.getIntensityfromScaledX(null, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(null, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(null, "b")).to.equal(0);
-
-      expect(color_grid.getIntensityfromScaledX(NaN, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(NaN, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(NaN, "b")).to.equal(0);
-
-      expect(color_grid.getIntensityfromScaledX(true, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(true, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(true, "b")).to.equal(0);
-
-      expect(color_grid.getIntensityfromScaledX(false, "r")).to.equal(255);
-      expect(color_grid.getIntensityfromScaledX(false, "g")).to.equal(0);
-      expect(color_grid.getIntensityfromScaledX(false, "b")).to.equal(0);
-    });
-  });
-});
-describe("getRgbFromScaledX", function() {
-  it("should return an Rgb object", function() {
-    var rgb = color_grid.getRgbFromScaledX(10);
-    expect(rgb instanceof color_grid.Rgb).to.equal(true);
-  });
-  it("should return an Rgb object with correct r, g, b values for the scaled mouse position given", function() {
-    expect(color_grid.getRgbFromScaledX(0).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(10).isEqual(new color_grid.Rgb(255,42,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(20).isEqual(new color_grid.Rgb(255,85,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(30).isEqual(new color_grid.Rgb(255,127,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(40).isEqual(new color_grid.Rgb(255,170,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(50).isEqual(new color_grid.Rgb(255,212,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(60).isEqual(new color_grid.Rgb(255,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(70).isEqual(new color_grid.Rgb(212,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(80).isEqual(new color_grid.Rgb(170,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(90).isEqual(new color_grid.Rgb(127,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(100).isEqual(new color_grid.Rgb(85,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(110).isEqual(new color_grid.Rgb(42,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(120).isEqual(new color_grid.Rgb(0,255,0))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(130).isEqual(new color_grid.Rgb(0,255,42))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(140).isEqual(new color_grid.Rgb(0,255,85))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(150).isEqual(new color_grid.Rgb(0,255,127))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(160).isEqual(new color_grid.Rgb(0,255,170))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(170).isEqual(new color_grid.Rgb(0,255,212))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(180).isEqual(new color_grid.Rgb(0,255,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(190).isEqual(new color_grid.Rgb(0,212,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(200).isEqual(new color_grid.Rgb(0,170,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(210).isEqual(new color_grid.Rgb(0,127,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(220).isEqual(new color_grid.Rgb(0,85,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(230).isEqual(new color_grid.Rgb(0,42,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(240).isEqual(new color_grid.Rgb(0,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(250).isEqual(new color_grid.Rgb(42,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(260).isEqual(new color_grid.Rgb(85,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(270).isEqual(new color_grid.Rgb(127,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(280).isEqual(new color_grid.Rgb(170,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(290).isEqual(new color_grid.Rgb(212,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(300).isEqual(new color_grid.Rgb(255,0,255))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(310).isEqual(new color_grid.Rgb(255,0,212))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(320).isEqual(new color_grid.Rgb(255,0,170))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(330).isEqual(new color_grid.Rgb(255,0,127))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(340).isEqual(new color_grid.Rgb(255,0,85))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(350).isEqual(new color_grid.Rgb(255,0,42))).to.equal(true);
-    expect(color_grid.getRgbFromScaledX(360).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-  });
-  describe("for input values less than 0", function() {
-    it("should return the Rgb object as if 0 were the input", function() {
-      expect(color_grid.getRgbFromScaledX(-10).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-    });
-  });
-  describe("for input values greater than 360", function() {
-    it("should return the Rgb object as if 0 were the input", function() {
-      expect(color_grid.getRgbFromScaledX(1000).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-    });
-  });
-  describe("for non-numeric input values", function() {
-    it("should return the Rgb object as if 0 were the input", function() {
-      expect(color_grid.getRgbFromScaledX("string").isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-      expect(color_grid.getRgbFromScaledX(undefined).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-      expect(color_grid.getRgbFromScaledX(null).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-      expect(color_grid.getRgbFromScaledX(NaN).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-      expect(color_grid.getRgbFromScaledX(true).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-      expect(color_grid.getRgbFromScaledX(false).isEqual(new color_grid.Rgb(255,0,0))).to.equal(true);
-    });
   });
 });

--- a/test/color-grid-test.js
+++ b/test/color-grid-test.js
@@ -65,13 +65,21 @@ describe("Hsl", function() {
   });
 });
 describe("getScaledX", function() {
-  it("should return the mouse position's value out of 360, given the mouse position and screen width", function() {
-    var screen_width = 1000,
-      mouse_position = 40,
-      scaled_mouse_position = color_grid.getScaledX(mouse_position, screen_width);
-    expect(scaled_mouse_position).to.equal(14.4);
+  it("should return the mouse position's value out of 360 as an whole number, given the mouse position and screen width", function() {
+    var scaled1 = color_grid.getScaledX(40,1000),
+      scaled2 = color_grid.getScaledX(11,1000);
+      scaled3 = color_grid.getScaledX(10,360);
+      scaled4 = color_grid.getScaledX(100.5,360);
+      scaled5 = color_grid.getScaledX(100.1,360);
+      scaled6 = color_grid.getScaledX(100.9,360);
+      expect(scaled1).to.equal(14);
+      expect(scaled2).to.equal(3);
+      expect(scaled3).to.equal(10);
+      expect(scaled4).to.equal(100);
+      expect(scaled5).to.equal(100);
+      expect(scaled6).to.equal(100);
   });
-  it("should return 360 when the mouse position is greather than the width of the screen", function() {
+  it("should return 360 when the mouse position is greater than the width of the screen", function() {
     var screen_width = 1000,
       mouse_position = 2000,
       scaled_mouse_position = color_grid.getScaledX(mouse_position, screen_width);
@@ -97,5 +105,70 @@ describe("getScaledX", function() {
     expect(color_grid.getScaledX(10, true)).to.equal(0);
     expect(color_grid.getScaledX(10, false)).to.equal(0);
     expect(color_grid.getScaledX(10, "string")).to.equal(0);
+  });
+});
+describe("getScaledY", function() {
+  it("should return correct scaled values between 15 and 85, inclusive", function() {
+    var scaled1 = color_grid.getScaledY(50.1, 100),
+      scaled2 = color_grid.getScaledY(50.5,100);
+      scaled3 = color_grid.getScaledY(0,70);
+      scaled4 = color_grid.getScaledY(1,70);
+      scaled5 = color_grid.getScaledY(69,70);
+      scaled6 = color_grid.getScaledY(70,70);
+      scaled7 = color_grid.getScaledY(69.9, 70);
+      scaled8 = color_grid.getScaledY(68.9, 70);
+      expect(scaled1).to.equal(50);
+      expect(scaled2).to.equal(50);
+      expect(scaled3).to.equal(15);
+      expect(scaled4).to.equal(16);
+      expect(scaled5).to.equal(84);
+      expect(scaled6).to.equal(85);
+      expect(scaled7).to.equal(84);
+      expect(scaled8).to.equal(83);
+  });
+  describe("for non numeric values", function() {
+    it("should return 15", function() {
+      var scaled1 = color_grid.getScaledY(true, 100),
+        scaled2 = color_grid.getScaledY(false, 100),
+        scaled3 = color_grid.getScaledY("string", 100),
+        scaled4 = color_grid.getScaledY(null, 100),
+        scaled5 = color_grid.getScaledY(),
+        scaled6 = color_grid.getScaledY(undefined, 100),
+        scaled7 = color_grid.getScaledY(NaN, 100),
+        scaled8 = color_grid.getScaledY(100, true),
+        scaled9 = color_grid.getScaledY(100, false),
+        scaled10 = color_grid.getScaledY(100, "string"),
+        scaled11 = color_grid.getScaledY(100, null),
+        scaled12 = color_grid.getScaledY(100),
+        scaled13 = color_grid.getScaledY(100, undefined),
+        scaled14 = color_grid.getScaledY(100, NaN);
+
+      expect(scaled1).to.equal(15);
+      expect(scaled2).to.equal(15);
+      expect(scaled3).to.equal(15);
+      expect(scaled4).to.equal(15);
+      expect(scaled5).to.equal(15);
+      expect(scaled6).to.equal(15);
+      expect(scaled7).to.equal(15);
+      expect(scaled8).to.equal(15);
+      expect(scaled9).to.equal(15);
+      expect(scaled10).to.equal(15);
+      expect(scaled11).to.equal(15);
+      expect(scaled12).to.equal(15);
+      expect(scaled13).to.equal(15);
+      expect(scaled14).to.equal(15);
+    });
+  });
+  describe("for mouse position less than 0", function() {
+    it("should return 15", function() {
+      var scaled = color_grid.getScaledY(-10, 100);
+      expect(scaled).to.equal(15);
+    });
+  });
+  describe("when the mouse position is greater than the height of the screen", function() {
+    it("should return 85", function() {
+      var scaled = color_grid.getScaledY(1000, 100);
+      expect(scaled).to.equal(85);
+    });
   });
 });


### PR DESCRIPTION
Fixes #1. Adds color changes in lightness when mouse moves up or down vertically.
- replaced Rgb with Hsl
- removed all functions that are related to Rgb and their unit tests
- added bodyY variable, and scaledY() function that returns a value from 15 to 85
- both scaledY() and scaledX() now return whole number values
- added unit tests for scaledY()
- renamed resize() to setWidthAndHeight() - this is now used to remember the height and width of the screen
- use clientX and clientY instead of screenX and screenY for correct y screen coordinates
- use only window.innerWidth to get screen width 

clean up and refactoring:
- removed addMouseOverFunc() function, and added its code inline instead
- moved currentBodyColor assignment to after Hsl defintion
- corrected unit tests for whitespace, spelling, jshint errors
